### PR TITLE
Sandbox endpoint

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -25,6 +25,7 @@ class Client
         if (is_array($config)) {
             $this->_token = $config["token"];
             $this->_profile_id = $config["profile_id"];
+            if($config["env"] == "sandbox") $this->_url = "https://api.sandbox.transferwise.tech";
             return;
         }
 


### PR DESCRIPTION
For use in the test environment, a new optional config variable _env_ with _sandbox_ as an option. Changes the endpoint to _https://api.sandbox.transferwise.tech_.